### PR TITLE
Replit Dev Env Setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ next-env.d.ts
 
 # build artifacts
 public/r/themes
+
+# attached_assets dir when using Replit Agent
+attached_assets

--- a/.replit
+++ b/.replit
@@ -1,0 +1,39 @@
+modules = ["nodejs-20", "web"]
+[agent]
+expertMode = true
+
+[nix]
+channel = "stable-25_05"
+
+[workflows]
+runButton = "Project"
+
+[[workflows.workflow]]
+name = "Project"
+mode = "parallel"
+author = "agent"
+
+[[workflows.workflow.tasks]]
+task = "workflow.run"
+args = "Frontend Development Server"
+
+[[workflows.workflow]]
+name = "Frontend Development Server"
+author = "agent"
+
+[[workflows.workflow.tasks]]
+task = "shell.exec"
+args = "next dev"
+waitForPort = 3000
+
+[workflows.workflow.metadata]
+outputType = "webview"
+
+[[ports]]
+localPort = 3000
+externalPort = 80
+
+[deployment]
+deploymentTarget = "autoscale"
+run = ["npm", "start"]
+build = ["npm", "run", "build"]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,12 +50,24 @@ Even if you don't plan to write code, there are many ways to contribute:
 - **Spread the Word:** If you like tweakcn.com, please share it with your friends, colleagues, and on social media. Helping grow the community makes the tool better for everyone.
 - **Use tweakcn.com:** The best feedback comes from real-world usage! As you use the editor, if you encounter any issues or have ideas for improvement, please let us know by creating an issue or reaching out on [Discord](https://discord.com/invite/Phs4u2NM3n).
 
+### Running on Replit
+
+You can run this project on Replit with no local setup or configuration. Replit will automatically provision and configure the required Neon database for development.
+
+1.  **Fork the Repository:** Start by creating your own copy of the [tweakcn repository](https://github.com/jnsahaj/tweakcn) on GitHub. Click the "Fork" button in the top-right corner.
+
+2.  **Import to Replit** Import the repository you just forked into Replit by going to:
+
+    `https://repl.new/github.com/YOUR_USERNAME/tweakcn.git`
+
+3.  Replit will automatically set up and run the required development environment
+
 ### Prerequisites
 
 - Node.js 18+
 - npm / yarn / pnpm
 
-### Installation
+### Local Installation
 
 1.  **Fork the Repository:** Start by creating your own copy of the [tweakcn repository](https://github.com/jnsahaj/tweakcn) on GitHub. Click the "Fork" button in the top-right corner.
 
@@ -74,7 +86,7 @@ Even if you don't plan to write code, there are many ways to contribute:
     npm install
     ```
 
-### Set up the development environment (follow closely)
+### Set up the local development environment (follow closely)
 
 1.  **Configure Environment Variables:** 
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,21 +1,73 @@
-import { type NextConfig } from "next";
+import type { NextConfig } from "next";
+
+const isReplit = Boolean(process.env.REPLIT_DEV_DOMAIN);
 
 const nextConfig: NextConfig = {
-  turbopack: {
-      rules: {
-        '*.svg': {
-          loaders: [
-            {
-              loader: '@svgr/webpack',
-              options: {
-                icon: true,
+  // Allow dev origins to prevent cross-origin warnings
+  ...(process.env.NODE_ENV === "development" && {
+    allowedDevOrigins: [
+      ...(process.env.REPLIT_DEV_DOMAIN ? [process.env.REPLIT_DEV_DOMAIN] : []),
+      "http://127.0.0.1:5000",
+      "http://localhost:5000",
+    ],
+  }),
+
+  // Use Webpack on Replit
+  ...(isReplit
+    ? {
+        webpack: (config) => {
+          config.module.rules.push({
+            test: /\.svg$/,
+            use: [
+              {
+                loader: "@svgr/webpack",
+                options: {
+                  icon: true,
+                  svgoConfig: {
+                    plugins: [
+                      {
+                        name: "preset-default",
+                        params: {
+                          overrides: { removeViewBox: false },
+                        },
+                      },
+                    ],
+                  },
+                },
               },
+            ],
+          });
+          return config;
+        },
+      }
+    : {
+        // Use Turbopack everywhere else
+        turbopack: {
+          rules: {
+            "*.svg": {
+              loaders: [
+                {
+                  loader: "@svgr/webpack",
+                  options: {
+                    icon: true,
+                    svgoConfig: {
+                      plugins: [
+                        {
+                          name: "preset-default",
+                          params: {
+                            overrides: { removeViewBox: false },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              ],
+              as: "*.js",
             },
-          ],
-        as: '*.js',
-      },
-    },
-  },
+          },
+        } as any,
+      }),
 };
 
 export default nextConfig;

--- a/replit.md
+++ b/replit.md
@@ -1,0 +1,62 @@
+# tweakcn - Visual Theme Editor for Tailwind CSS & shadcn/ui
+
+## Overview
+
+tweakcn.com is a powerful visual theme editor designed for Tailwind CSS and shadcn/ui components. The platform allows users to visually customize themes, preview changes in real-time, and export themes for use in their projects. The application includes AI-powered theme generation, a comprehensive component library for previews, and user management features for saving and sharing custom themes.
+
+## User Preferences
+
+Preferred communication style: Simple, everyday language.
+
+## System Architecture
+
+### Frontend Architecture
+- **Framework**: Next.js 15 with App Router (Webpack-based, Turbopack disabled for Replit compatibility)
+- **State Management**: Zustand for global state with persistence via IndexedDB
+- **Styling**: Tailwind CSS v4 with custom CSS variables for theme tokens
+- **UI Components**: shadcn/ui components with Radix UI primitives
+- **Type Safety**: TypeScript with strict configuration
+- **Real-time Updates**: Custom theme application system that updates CSS variables dynamically
+
+### Backend Architecture
+- **Runtime**: Next.js API routes with Server Actions
+- **Authentication**: Better Auth with social providers (Google, GitHub)
+- **Database**: PostgreSQL with Drizzle ORM for type-safe database operations
+- **Theme Storage**: JSON-based theme styles with validation schemas using Zod
+- **AI Integration**: Google Generative AI (Gemini 2.5 Pro) for theme generation
+- **File Handling**: Image upload and processing for AI prompt enhancement
+
+### Data Storage Solutions
+- **Primary Database**: PostgreSQL via Neon serverless
+- **Schema**: User accounts, sessions, themes, AI usage tracking, and subscription management
+- **Client Storage**: IndexedDB for offline state persistence and draft storage
+- **Static Assets**: Theme registry files stored in public directory
+
+### Authentication and Authorization
+- **Provider**: Better Auth with Drizzle adapter
+- **Social Login**: Google and GitHub OAuth integration
+- **Session Management**: Secure token-based sessions with database storage
+- **Route Protection**: Middleware-based authentication for protected routes
+- **Access Control**: Subscription-based feature gating for premium functionality
+
+### External Dependencies
+
+#### Third-party Services
+- **Neon Database**: PostgreSQL hosting and serverless database access
+- **Polar**: Subscription management and checkout processing
+- **PostHog**: Analytics and user behavior tracking
+- **Google Fonts API**: Dynamic font loading for typography customization
+- **Vercel**: Hosting and deployment platform
+
+#### APIs and Integrations
+- **Google Generative AI**: Theme generation from text and image prompts
+- **GitHub API**: Repository information and star counts
+- **Polar Checkout**: Payment processing and subscription management
+- **Google Fonts**: Font family search and loading
+
+#### Development Tools
+- **Drizzle Kit**: Database migrations and schema management
+- **SWR**: Data fetching and caching for GitHub API
+- **React Query**: Server state management and caching
+- **Motion**: Animation library for smooth transitions
+- **Nuqs**: URL state management for theme presets and navigation


### PR DESCRIPTION
Adds replit.md and some environment setup for running TweakCN on Replit using Github import.

Modifies next.config.ts to use webpack only when on Replit (Replit itself uses turbopack so the existing turbopack config can't run) and use REPLIT_DEV_DOMAIN as an allowedDevOrigin

Anyone can spin up a TweakCN dev env of their fork by going to:

https://repl.new/github.com/YOUR_USERNAME/tweakcn.git

Replit gives you a free Postgres DB setup (so no having to separately setup neon) which will automatically wire up on import.